### PR TITLE
mysql 세팅/연결 방법

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	runtimeOnly 'com.mysql:mysql-connector-j'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/igemoney/igemoney_BE/IgemoneyBeApplication.java
+++ b/src/main/java/com/igemoney/igemoney_BE/IgemoneyBeApplication.java
@@ -2,11 +2,9 @@ package com.igemoney.igemoney_BE;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 
 
-// todo: db 의존성 설치하면 exclude 속성 지워버리기
-@SpringBootApplication(exclude={ DataSourceAutoConfiguration.class})
+@SpringBootApplication()
 public class IgemoneyBeApplication {
 
 	public static void main(String[] args) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,18 @@
 spring:
   application:
     name: igemoney_BE
+
+  datasource:
+    url: jdbc:mysql://localhost:3306/igemoney-mysql
+    username: root
+    password: 1234
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: update  # create, create-drop, validate, update, none
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
+        format_sql: true
+


### PR DESCRIPTION
mysql로 RDBMS 결정하기로 해서 mysql을 연결하는 코드 작성했습니다.
**(데이터베이스명: igemoney-mysql, 루트 암호: 1234, 포트 3306 기준)**

각자의 로컬에서 다음처럼 사용하시길 바랍니다

## 이미 로컬에 mysql 자체가 이미 깔려있다면?
1. mysql의 점유 포트를 확인하고 다르다면 yml 문서에서 포트를 바꿔주세요.
2. 데이터베이스 `igemoney-mysql`를 생성해주세요. 

## docker로 mysql 컨테이너를 돌려 딸깍으로 하고싶다면?
``` 
docker run -d \
  --name igemoney-mysql \
  -e MYSQL_ROOT_PASSWORD=1234 \
  -e MYSQL_DATABASE=igemoney-mysql \
  -p 3306:3306 \
  mysql:latest
```


