### PR TITLE
docs: Epic/Task/Bug 이슈 관리용 템플릿 신규 생성

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,47 @@
+name: Bug
+description: 버그 제보/수정
+title: "[Bug]: "
+labels: [bug]
+body:
+  - type: dropdown
+    id: severity
+    attributes:
+      label: 심각도
+      options: [blocker, critical, major, minor, trivial]
+    validations:
+      required: true
+
+  - type: input
+    id: env
+    attributes:
+      label: 환경
+      placeholder: ex) dev, Java 17 / Spring Boot 3.x
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: 재현 단계
+      placeholder: |
+        1) ...
+        2) ...
+        3) ...
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: 기대 동작
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: 실제 동작/로그
+
+  - type: checkboxes
+    id: impact
+    attributes:
+      label: 영향도
+      options:
+        - label: 데이터 손상 우려
+        - label: 보안 이슈
+        - label: 설정(application.yml) 관련
+

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -1,0 +1,36 @@
+name: Epic
+description: 큰 단위 작업을 정의합니다.
+title: "[Epic]: "
+labels: [epic]
+body:
+  - type: input
+    id: goal
+    attributes:
+      label: 목표(한 줄)
+      placeholder: ex) 회원 관리 기능 구현
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: 범위(간단)
+      placeholder: 포함 / 제외
+
+  - type: textarea
+    id: subissues
+    attributes:
+      label: 서브 이슈(번호로 연결)
+      description: 생성된 Task/Bug 이슈 번호를 체크박스로 적어주세요.
+      placeholder: |
+        - [ ] #123 회원가입 API
+        - [ ] #124 로그인 API
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: 완료 기준
+      placeholder: ex) 주요 시나리오 동작, 기본 테스트 통과
+    validations:
+      required: true
+

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,43 @@
+name: Task
+description: 실제 작업 단위(기능, 리팩토링, 설정 변경)
+title: "[Task]: "
+labels: [task]
+body:
+  - type: input
+    id: summary
+    attributes:
+      label: 작업 요약
+      placeholder: ex) 회원가입 API 작성
+    validations:
+      required: true
+
+  - type: input
+    id: parent
+    attributes:
+      label: 상위 Epic(선택)
+      placeholder: ex) #120
+
+  - type: textarea
+    id: details
+    attributes:
+      label: 상세 내용(간단)
+      placeholder: 변경 포인트, 설계/의사결정 메모
+
+  - type: checkboxes
+    id: impacts
+    attributes:
+      label: 영향도
+      options:
+        - label: DB 스키마/마이그레이션 영향
+        - label: application.yml / profile 변경
+        - label: 보안/권한 영향
+
+  - type: textarea
+    id: checklist
+    attributes:
+      label: 체크리스트
+      placeholder: |
+        - [ ] 브랜치 생성
+        - [ ] 코드 작성
+        - [ ] 로컬 빌드/테스트 통과
+


### PR DESCRIPTION
## #️⃣ 연관된 이슈
### 없음!

## #️⃣ 작업 내용

> 이슈 템플릿 작성
> Epic / Task / Bug 3개의 이슈를 구분하여 작성할 수 있도록 구성함.
> yml 파일로 작성함.

## #️⃣ 스크린샷 (선택)
### 없음!


## 주의사항
### 작성 순서에 대해서 알려드릴게요 
1. 큰 단위의 작업 이슈 등록: Epic 파일로 작성하시면 됩니다.(로그인 구현)
2. 작은 단위(PR 단위의 작업)은 Task 파일로 작성하시면 됩니다. (소셜로그인, 구글 로그인)
3. Task 파일로 작성하면 해당 이슈에 대한 이슈 번호가 배정될 겁니다.(ex. #10)
4. 해당 Task의 이슈 번호를 이전에 작성해둔 Epic 이슈 파일 내에 체크리스트에 Task 이슈 번호 적어두면 자동 링크 됩니다.
5. 여기서 자동 링크의 의미는 PR 본문에서 이슈 번호를 Closed 한다는 내용을 작성(Closes #101)하면 
6. Task 이슈는 자동으로 닫히고 
7. Epic 이슈 내에 체크리스트도 자동으로 체크된 상태가 반영될 겁니다.
---
**이해 안되면 저에게 직접 물어봐주세용~~!**
