### PR TITLE
feat: vite 환경인 5173 로컬호스트도 추가

### DIFF
--- a/src/main/java/com/igemoney/igemoney_BE/config/WebConfig.java
+++ b/src/main/java/com/igemoney/igemoney_BE/config/WebConfig.java
@@ -12,7 +12,10 @@ public class WebConfig implements WebMvcConfigurer {
 	@Override
 	public void addCorsMappings(CorsRegistry registry) {
 		registry.addMapping("/**")
-			.allowedOrigins("https://egemoney.vercel.app")
+			.allowedOrigins(
+				"https://egemoney.vercel.app",
+				"http://localhost:5173"
+			)
 			.allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
 			.allowedHeaders("*")
 			.allowCredentials(true)


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#11 

## #️⃣ 작업 내용

왜 계속 프론트에서 cors가 뜨냐 세팅을 했는데도..! 그건 바로 테스트 환경이 vite인 localhost:5173였기 때문.. vercel이 아니라..
