### PR TITLE
퀴즈 문제 조회 및 답안 제출 로직 95% 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,8 +33,6 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	runtimeOnly 'com.mysql:mysql-connector-j'
-	testImplementation 'com.h2database:h2' // CI 환경엔 디비가 없기 때문에 오류 터져서 CI 실패, 따라서 거기서 디비 역할을 해주는 용도
-
 }
 
 tasks.named('test') {

--- a/src/main/java/com/igemoney/igemoney_BE/quiz/controller/QuizController.java
+++ b/src/main/java/com/igemoney/igemoney_BE/quiz/controller/QuizController.java
@@ -2,6 +2,7 @@ package com.igemoney.igemoney_BE.quiz.controller;
 
 import com.igemoney.igemoney_BE.quiz.dto.QuizCreateRequest;
 import com.igemoney.igemoney_BE.quiz.dto.QuizResponse;
+import com.igemoney.igemoney_BE.quiz.dto.QuizSubmitRequest;
 import com.igemoney.igemoney_BE.quiz.entity.Quiz;
 import com.igemoney.igemoney_BE.quiz.service.QuizService;
 import lombok.RequiredArgsConstructor;
@@ -29,4 +30,16 @@ public class QuizController {
     public List<QuizResponse> getAllQuizzes() {
         return quizService.getAll();
     }
+
+    @GetMapping("/{id}")
+    public QuizResponse getQuiz(@PathVariable Long id) {
+        return quizService.getQuizInfo(id);
+    }
+
+    @PostMapping("/{id}/submit")
+    public void submitQuizResult(@PathVariable Long id, @RequestBody QuizSubmitRequest request) {
+        quizService.submitQuizResult(id, request);
+    }
+
+
 }

--- a/src/main/java/com/igemoney/igemoney_BE/quiz/dto/QuizSubmitRequest.java
+++ b/src/main/java/com/igemoney/igemoney_BE/quiz/dto/QuizSubmitRequest.java
@@ -1,0 +1,7 @@
+package com.igemoney.igemoney_BE.quiz.dto;
+
+
+public record QuizSubmitRequest(
+	boolean isCorrect
+) {
+}

--- a/src/main/java/com/igemoney/igemoney_BE/quiz/entity/Quiz.java
+++ b/src/main/java/com/igemoney/igemoney_BE/quiz/entity/Quiz.java
@@ -1,14 +1,13 @@
 package com.igemoney.igemoney_BE.quiz.entity;
 
 import com.igemoney.igemoney_BE.common.entity.BaseEntity;
+import com.igemoney.igemoney_BE.quiz.entity.enums.DifficultyLevel;
+import com.igemoney.igemoney_BE.quiz.entity.enums.QuestionType;
 import jakarta.persistence.*;
 import lombok.*;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
+
 
 @Entity
 @Table(name = "quiz")

--- a/src/main/java/com/igemoney/igemoney_BE/quiz/entity/Quiz.java
+++ b/src/main/java/com/igemoney/igemoney_BE/quiz/entity/Quiz.java
@@ -13,10 +13,8 @@ import java.time.LocalDateTime;
 @Entity
 @Table(name = "quiz")
 @Getter
-@Setter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Builder
 public class Quiz extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -48,4 +46,18 @@ public class Quiz extends BaseEntity {
 
     @Column(name = "correct_rate", precision = 5, scale = 2)
     private BigDecimal correctRate;
+
+
+    @Builder
+    public Quiz(QuizTopic topic, String questionTitle, QuestionType questionType, String questionData, DifficultyLevel difficultyLevel, String explanation, Integer questionOrder) {
+        this.topic = topic;
+        this.questionTitle = questionTitle;
+        this.questionType = questionType;
+        this.questionData = questionData;
+        this.difficultyLevel = difficultyLevel;
+        this.explanation = explanation;
+        this.questionOrder = questionOrder;
+        this.correctRate = BigDecimal.ZERO;
+    }
+
 }

--- a/src/main/java/com/igemoney/igemoney_BE/quiz/entity/UserQuizCorrect.java
+++ b/src/main/java/com/igemoney/igemoney_BE/quiz/entity/UserQuizCorrect.java
@@ -15,7 +15,7 @@ import lombok.NoArgsConstructor;
 public class UserQuizCorrect extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long userQuizSolvedId;
+	private Long userQuizCorrectId;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id", nullable = false)

--- a/src/main/java/com/igemoney/igemoney_BE/quiz/entity/UserQuizCorrect.java
+++ b/src/main/java/com/igemoney/igemoney_BE/quiz/entity/UserQuizCorrect.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class UserQuizSolved extends BaseEntity {
+public class UserQuizCorrect extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long userQuizSolvedId;

--- a/src/main/java/com/igemoney/igemoney_BE/quiz/entity/UserQuizCorrect.java
+++ b/src/main/java/com/igemoney/igemoney_BE/quiz/entity/UserQuizCorrect.java
@@ -5,6 +5,7 @@ import com.igemoney.igemoney_BE.common.entity.BaseEntity;
 import com.igemoney.igemoney_BE.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -24,5 +25,11 @@ public class UserQuizCorrect extends BaseEntity {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "quiz_id", nullable = false)
 	private Quiz quiz;
+
+	@Builder
+	public UserQuizCorrect(User user, Quiz quiz) {
+		this.user = user;
+		this.quiz = quiz;
+	}
 
 }

--- a/src/main/java/com/igemoney/igemoney_BE/quiz/entity/UserQuizIncorrect.java
+++ b/src/main/java/com/igemoney/igemoney_BE/quiz/entity/UserQuizIncorrect.java
@@ -1,0 +1,82 @@
+package com.igemoney.igemoney_BE.quiz.entity;
+
+
+import com.igemoney.igemoney_BE.common.entity.BaseEntity;
+import com.igemoney.igemoney_BE.quiz.entity.enums.ReviewStep;
+import com.igemoney.igemoney_BE.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserQuizIncorrect extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "quiz_id", nullable = false)
+	private Quiz quiz;
+
+	@Column
+	private LocalDate nextReviewDate;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, columnDefinition = "enum('D1','D4','DONE') default 'D1'")
+	private ReviewStep reviewCycle;
+
+	@Column(nullable = false, columnDefinition = "TINYINT(1) DEFAULT 0")
+	private Boolean isCompleted;
+
+
+	@Builder
+	public UserQuizIncorrect(User user, Quiz quiz) {
+		this.user = user;
+		this.quiz = quiz;
+		this.nextReviewDate = LocalDate.now(ZoneId.of("Asia/Seoul")).plusDays(1);
+		this.reviewCycle = ReviewStep.D1;
+		this.isCompleted = false;
+	}
+
+
+	public void updateOnCorrectReview() {
+		if (this.isCompleted){
+			return;
+		}
+
+		if (this.reviewCycle == ReviewStep.D1){
+			this.reviewCycle = ReviewStep.D4;
+			this.nextReviewDate = LocalDate.now(ZoneId.of("Asia/Seoul")).plusDays(4);
+		} else if (this.reviewCycle == ReviewStep.D4){
+			this.reviewCycle = ReviewStep.DONE;
+			this.isCompleted = true;
+			this.nextReviewDate = null;
+		}
+	}
+
+	public void updateOnIncorrectReview() {
+		if (this.isCompleted){
+			return;
+		}
+
+		if (this.reviewCycle == ReviewStep.D1){
+			this.nextReviewDate = LocalDate.now(ZoneId.of("Asia/Seoul")).plusDays(1);
+		} else if (this.reviewCycle == ReviewStep.D4){
+			this.reviewCycle = ReviewStep.D1;
+			this.nextReviewDate = LocalDate.now(ZoneId.of("Asia/Seoul")).plusDays(1);
+		}
+	}
+
+}

--- a/src/main/java/com/igemoney/igemoney_BE/quiz/entity/UserQuizSolved.java
+++ b/src/main/java/com/igemoney/igemoney_BE/quiz/entity/UserQuizSolved.java
@@ -1,0 +1,28 @@
+package com.igemoney.igemoney_BE.quiz.entity;
+
+
+import com.igemoney.igemoney_BE.common.entity.BaseEntity;
+import com.igemoney.igemoney_BE.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserQuizSolved extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long userQuizSolvedId;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "quiz_id", nullable = false)
+	private Quiz quiz;
+
+}

--- a/src/main/java/com/igemoney/igemoney_BE/quiz/entity/enums/DifficultyLevel.java
+++ b/src/main/java/com/igemoney/igemoney_BE/quiz/entity/enums/DifficultyLevel.java
@@ -1,4 +1,4 @@
-package com.igemoney.igemoney_BE.quiz.entity;
+package com.igemoney.igemoney_BE.quiz.entity.enums;
 
 public enum DifficultyLevel {
     EASY,

--- a/src/main/java/com/igemoney/igemoney_BE/quiz/entity/enums/QuestionType.java
+++ b/src/main/java/com/igemoney/igemoney_BE/quiz/entity/enums/QuestionType.java
@@ -1,4 +1,4 @@
-package com.igemoney.igemoney_BE.quiz.entity;
+package com.igemoney.igemoney_BE.quiz.entity.enums;
 
 public enum QuestionType {
     MULTIPLE_CHOICE,

--- a/src/main/java/com/igemoney/igemoney_BE/quiz/entity/enums/ReviewStep.java
+++ b/src/main/java/com/igemoney/igemoney_BE/quiz/entity/enums/ReviewStep.java
@@ -1,0 +1,6 @@
+package com.igemoney.igemoney_BE.quiz.entity.enums;
+
+
+public enum ReviewStep {
+	D1, D4, DONE
+}

--- a/src/main/java/com/igemoney/igemoney_BE/quiz/repository/UserQuizCorrectRepository.java
+++ b/src/main/java/com/igemoney/igemoney_BE/quiz/repository/UserQuizCorrectRepository.java
@@ -1,0 +1,9 @@
+package com.igemoney.igemoney_BE.quiz.repository;
+
+
+import com.igemoney.igemoney_BE.quiz.entity.UserQuizCorrect;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+public interface UserQuizCorrectRepository extends JpaRepository<UserQuizCorrect, Long> {
+}

--- a/src/main/java/com/igemoney/igemoney_BE/quiz/repository/UserQuizIncorrectRepository.java
+++ b/src/main/java/com/igemoney/igemoney_BE/quiz/repository/UserQuizIncorrectRepository.java
@@ -1,0 +1,9 @@
+package com.igemoney.igemoney_BE.quiz.repository;
+
+
+import com.igemoney.igemoney_BE.quiz.entity.UserQuizIncorrect;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+public interface UserQuizIncorrectRepository extends JpaRepository<UserQuizIncorrect, Long> {
+}

--- a/src/main/java/com/igemoney/igemoney_BE/quiz/service/QuizService.java
+++ b/src/main/java/com/igemoney/igemoney_BE/quiz/service/QuizService.java
@@ -1,67 +1,118 @@
 package com.igemoney.igemoney_BE.quiz.service;
 
+
 import com.igemoney.igemoney_BE.quiz.dto.QuizCreateRequest;
 import com.igemoney.igemoney_BE.quiz.dto.QuizResponse;
+import com.igemoney.igemoney_BE.quiz.dto.QuizSubmitRequest;
+import com.igemoney.igemoney_BE.quiz.entity.UserQuizCorrect;
+import com.igemoney.igemoney_BE.quiz.entity.UserQuizIncorrect;
 import com.igemoney.igemoney_BE.quiz.entity.enums.DifficultyLevel;
 import com.igemoney.igemoney_BE.quiz.entity.enums.QuestionType;
 import com.igemoney.igemoney_BE.quiz.entity.Quiz;
 import com.igemoney.igemoney_BE.quiz.entity.QuizTopic;
 import com.igemoney.igemoney_BE.quiz.repository.QuizRepository;
 import com.igemoney.igemoney_BE.quiz.repository.TopicRepository;
+import com.igemoney.igemoney_BE.quiz.repository.UserQuizCorrectRepository;
+import com.igemoney.igemoney_BE.quiz.repository.UserQuizIncorrectRepository;
+import com.igemoney.igemoney_BE.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class QuizService {
-    private final QuizRepository quizRepository;
-    private final TopicRepository topicRepository;
-    public Quiz createQuiz(QuizCreateRequest request) {
-        QuizTopic topic = topicRepository.findById(request.topicId())
-                .orElseThrow(() -> new IllegalArgumentException("Topic not found"));
 
-        Quiz quiz = Quiz.builder()
-                .questionTitle(request.questionTitle())
-                .questionType(QuestionType.valueOf(request.questionType()))
-                .questionData(request.questionData())
-                .difficultyLevel(DifficultyLevel.valueOf(request.difficultyLevel()))
-                .explanation(request.explanation())
-                .questionOrder(request.questionOrder())
-                .topic(topic)
-                .build();
+	private final QuizRepository quizRepository;
+	private final TopicRepository topicRepository;
+	private final UserQuizCorrectRepository userQuizCorrectRepository;
+	private final UserQuizIncorrectRepository userQuizIncorrectRepository;
 
-        return quizRepository.save(quiz);
-    }
 
-    public void deleteQuiz(Long id) {
-        quizRepository.deleteById(id);
-    }
+	public Quiz createQuiz(QuizCreateRequest request) {
+		QuizTopic topic = topicRepository.findById(request.topicId())
+			.orElseThrow(() -> new IllegalArgumentException("Topic not found"));
 
-    @Transactional(readOnly = true)
-    public List<QuizResponse> getAll() {
-        return quizRepository.findAll().stream()
-                .map(this::toResponse)
-                .toList();
-    }
+		Quiz quiz = Quiz.builder()
+			.questionTitle(request.questionTitle())
+			.questionType(QuestionType.valueOf(request.questionType()))
+			.questionData(request.questionData())
+			.difficultyLevel(DifficultyLevel.valueOf(request.difficultyLevel()))
+			.explanation(request.explanation())
+			.questionOrder(request.questionOrder())
+			.topic(topic)
+			.build();
 
-    private QuizResponse toResponse(Quiz q) {
-        return new QuizResponse(
-                q.getQuizId(),
-                q.getQuestionTitle(),
-                q.getQuestionType().name(),
-                q.getQuestionData(),
-                q.getDifficultyLevel().name(),
-                q.getExplanation(),
-                q.getQuestionOrder(),
-                q.getCorrectRate(),
-                q.getTopic().getId(),
-                q.getTopic().getName(),
-                q.getCreatedAt(),
-                q.getUpdatedAt()
-        );
-    }
+		return quizRepository.save(quiz);
+	}
+
+
+	public void deleteQuiz(Long id) {
+		quizRepository.deleteById(id);
+	}
+
+
+	@Transactional(readOnly = true)
+	public List<QuizResponse> getAll() {
+		return quizRepository.findAll().stream()
+			.map(this::toResponse)
+			.toList();
+	}
+
+
+	private QuizResponse toResponse(Quiz q) {
+		return new QuizResponse(
+			q.getQuizId(),
+			q.getQuestionTitle(),
+			q.getQuestionType().name(),
+			q.getQuestionData(),
+			q.getDifficultyLevel().name(),
+			q.getExplanation(),
+			q.getQuestionOrder(),
+			q.getCorrectRate(),
+			q.getTopic().getId(),
+			q.getTopic().getName(),
+			q.getCreatedAt(),
+			q.getUpdatedAt()
+		);
+	}
+
+
+	public QuizResponse getQuizInfo(Long id) {
+		Quiz quiz = quizRepository.findById(id)
+			.orElseThrow(() -> new IllegalArgumentException("Quiz not found"));
+
+		return toResponse(quiz);
+	}
+
+
+	// todo: 인증인가 들어오면 userId도 받고 User 찾는 로직 채워넣기
+	public void submitQuizResult(Long quizId, QuizSubmitRequest request) {
+		Quiz quiz = quizRepository.findById(quizId)
+			.orElseThrow(() -> new IllegalArgumentException("Quiz not found"));
+
+		//	    User user = userRepository.findById()
+		//	        .orElseThrow(() -> new IllegalArgumentException("User not found"));
+
+		if (request.isCorrect()) {
+			UserQuizCorrect userQuizCorrect = UserQuizCorrect.builder()
+				.user(new User())
+				.quiz(quiz)
+				.build();
+
+			userQuizCorrectRepository.save(userQuizCorrect);
+		} else {
+			UserQuizIncorrect userQuizIncorrect = UserQuizIncorrect.builder()
+				.user(new User())
+				.quiz(quiz)
+				.build();
+
+			userQuizIncorrectRepository.save(userQuizIncorrect);
+		}
+	}
+
 }

--- a/src/main/java/com/igemoney/igemoney_BE/quiz/service/QuizService.java
+++ b/src/main/java/com/igemoney/igemoney_BE/quiz/service/QuizService.java
@@ -2,8 +2,8 @@ package com.igemoney.igemoney_BE.quiz.service;
 
 import com.igemoney.igemoney_BE.quiz.dto.QuizCreateRequest;
 import com.igemoney.igemoney_BE.quiz.dto.QuizResponse;
-import com.igemoney.igemoney_BE.quiz.entity.DifficultyLevel;
-import com.igemoney.igemoney_BE.quiz.entity.QuestionType;
+import com.igemoney.igemoney_BE.quiz.entity.enums.DifficultyLevel;
+import com.igemoney.igemoney_BE.quiz.entity.enums.QuestionType;
 import com.igemoney.igemoney_BE.quiz.entity.Quiz;
 import com.igemoney.igemoney_BE.quiz.entity.QuizTopic;
 import com.igemoney.igemoney_BE.quiz.repository.QuizRepository;

--- a/src/main/java/com/igemoney/igemoney_BE/quiz/service/QuizService.java
+++ b/src/main/java/com/igemoney/igemoney_BE/quiz/service/QuizService.java
@@ -31,7 +31,6 @@ public class QuizService {
                 .difficultyLevel(DifficultyLevel.valueOf(request.difficultyLevel()))
                 .explanation(request.explanation())
                 .questionOrder(request.questionOrder())
-                .correctRate(request.correctRate())
                 .topic(topic)
                 .build();
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,7 +11,8 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      # todo: 배포단에선 update로 바꾸기
+      ddl-auto: create
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,2 +1,78 @@
-INSERT INTO user (nickname, oauth_id, rating_point, consecutive_attendance, today_count, is_active, created_at, updated_at)
-VALUES ('테스트유저', 'test_oauth_123', 0, 1, 0, 1, NOW(), NOW());
+-- 퀴즈 토픽 데이터 삽입
+INSERT INTO quiz_topic (name, created_at, updated_at)
+VALUES
+    ('경제기초',     NOW(), NOW()),
+    ('주식투자',     NOW(), NOW()),
+    ('글로벌 경제', NOW(), NOW()),
+    ('생활 경제',   NOW(), NOW()),
+    ('부동산',      NOW(), NOW());
+
+-- OX 퀴즈 데이터 삽입
+INSERT INTO quiz (
+    topic_id,
+    question_title,
+    question_type,
+    question_data,
+    difficulty_level,
+    explanation,
+    question_order,
+    correct_rate,
+    created_at,
+    updated_at
+)
+VALUES
+    (1,
+     '인플레이션은 물가 상승을 의미한다',
+     'OX',
+     '{"correctAnswer": true}',
+     'EASY',
+     '인플레이션은 일반적인 물가 수준이 지속적으로 상승하는 현상을 말합니다.',
+     1,
+     0.00,
+     NOW(),
+     NOW()
+    ),
+    (2,
+     '주식의 액면가는 시장가격과 항상 같다',
+     'OX',
+     '{"correctAnswer": false}',
+     'MEDIUM',
+     '주식의 액면가는 주식 발행 시 정해진 명목상의 가격이고, 시장가격은 수요와 공급에 따라 결정되는 실제 거래 가격입니다.',
+     2,
+     0.00,
+     NOW(),
+     NOW()
+    ),
+    (3,
+     '미국의 기준금리 인상은 전 세계 경제에 영향을 미친다',
+     'OX',
+     '{"correctAnswer": true}',
+     'HARD',
+     '미국 달러는 기축통화로서 미국의 금리 정책은 자본 흐름과 환율에 영향을 주어 전 세계 경제에 파급효과를 미칩니다.',
+     3,
+     0.00,
+     NOW(),
+     NOW()
+    ),
+    (4,
+     '신용카드 리볼빙 서비스는 무이자로 이용할 수 있다',
+     'OX',
+     '{"correctAnswer": false}',
+     'EASY',
+     '신용카드 리볼빙 서비스는 미납금에 대해 높은 이자율(연 15-25%)이 적용되는 단기 대출 서비스입니다.',
+     4,
+     0.00,
+     NOW(),
+     NOW()
+    ),
+    (5,
+     '전세금 반환보증보험은 의무적으로 가입해야 한다',
+     'OX',
+     '{"correctAnswer": false}',
+     'MEDIUM',
+     '전세금 반환보증보험은 임차인이 선택적으로 가입할 수 있는 보험 상품이며, 의무사항은 아닙니다.',
+     5,
+     0.00,
+     NOW(),
+     NOW()
+    );


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#45 

## #️⃣ 작업 내용
정답내역을 기록하는 UserQuizCorrect 테이블 및 레포지토리, 오답내역 기록 및 스케줄링 로직에 활용되는 UserQuizIncorrect 테이블 및 레포지토리 구현했습니다.

data.sql에 목업데이터로 퀴즈데이터 5개를 추가해놨습니다.

`getQuizInfo()` => 퀴즈 문제를 조회하는 api 기능을 구현했습니다. 논의했던대로 답안도 같이 넘겨 정답 체크는 프론트에서 수행합니다.

`submitQuizResult()` => 프론트에서 유저의 정답/오답 여부를 보내는 API입니다. 정답이면 UserQuizCorrect에, 그렇지 않다면 incorrect에 기록하게 서비스함수에 적어놨습니다. 아직 인증인가 작업이 들어와있지 않은 상황이라 User를 임시로 noarg생성자로 넣어놨습니다. 추후 수정 예정입니다.


