### PR TITLE
카카오 로그인/회원가입 + JWT 기반 인증 인가 검증로직 + 민감정보 환경변수화 + 커스텀 에러 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+.env
 
 # ============ IDE ============
 # IntelliJ IDEA

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
 	compileOnly 'io.jsonwebtoken:jjwt-api:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+	implementation 'me.paulschwarz:spring-dotenv:4.0.0'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,10 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	runtimeOnly 'com.mysql:mysql-connector-j'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	compileOnly 'io.jsonwebtoken:jjwt-api:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/igemoney/igemoney_BE/common/annotation/Authenticated.java
+++ b/src/main/java/com/igemoney/igemoney_BE/common/annotation/Authenticated.java
@@ -1,0 +1,15 @@
+package com.igemoney.igemoney_BE.common.annotation;
+
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface Authenticated {
+
+}

--- a/src/main/java/com/igemoney/igemoney_BE/common/config/WebConfig.java
+++ b/src/main/java/com/igemoney/igemoney_BE/common/config/WebConfig.java
@@ -1,13 +1,19 @@
 package com.igemoney.igemoney_BE.common.config;
 
 
+import com.igemoney.igemoney_BE.common.interceptor.AuthenticationInterceptor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 
 @Configuration
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
+
+	private final AuthenticationInterceptor authenticationInterceptor;
 
 	@Override
 	public void addCorsMappings(CorsRegistry registry) {
@@ -21,4 +27,13 @@ public class WebConfig implements WebMvcConfigurer {
 			.allowCredentials(true)
 			.maxAge(3600);
 	}
+
+
+	@Override
+	public void addInterceptors(InterceptorRegistry registry) {
+		registry.addInterceptor(authenticationInterceptor)
+			.addPathPatterns("/**")
+			.excludePathPatterns("/api/user/**");
+	}
+
 }

--- a/src/main/java/com/igemoney/igemoney_BE/common/exception/ErrorResponse.java
+++ b/src/main/java/com/igemoney/igemoney_BE/common/exception/ErrorResponse.java
@@ -1,0 +1,21 @@
+package com.igemoney.igemoney_BE.common.exception;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ErrorResponse {
+    private final int statusCode;
+    private final String message;
+    private final LocalDateTime timestamp;
+
+    @Builder
+    public ErrorResponse(int statusCode, String message) {
+        this.statusCode = statusCode;
+        this.message = message;
+        this.timestamp = LocalDateTime.now();
+    }
+
+}

--- a/src/main/java/com/igemoney/igemoney_BE/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/igemoney/igemoney_BE/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,22 @@
+package com.igemoney.igemoney_BE.common.exception;
+
+import com.igemoney.igemoney_BE.common.exception.user.NotRegisteredUserException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(NotRegisteredUserException.class)
+    public ResponseEntity<ErrorResponse> handleNotRegisteredUserException(NotRegisteredUserException e) {
+        ErrorResponse errorBody = ErrorResponse.builder()
+            .message(e.getMessage())
+            .statusCode(HttpStatus.UNAUTHORIZED.value())
+            .build();
+
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(errorBody);
+    }
+
+}

--- a/src/main/java/com/igemoney/igemoney_BE/common/exception/user/NotRegisteredUserException.java
+++ b/src/main/java/com/igemoney/igemoney_BE/common/exception/user/NotRegisteredUserException.java
@@ -1,0 +1,8 @@
+package com.igemoney.igemoney_BE.common.exception.user;
+
+public class NotRegisteredUserException  extends RuntimeException{
+    public NotRegisteredUserException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/com/igemoney/igemoney_BE/common/interceptor/AuthenticationInterceptor.java
+++ b/src/main/java/com/igemoney/igemoney_BE/common/interceptor/AuthenticationInterceptor.java
@@ -1,0 +1,64 @@
+package com.igemoney.igemoney_BE.common.interceptor;
+
+
+import com.igemoney.igemoney_BE.common.annotation.Authenticated;
+import com.igemoney.igemoney_BE.common.utils.JwtUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.ModelAndView;
+
+
+@Component
+@RequiredArgsConstructor
+public class AuthenticationInterceptor implements HandlerInterceptor {
+
+    private final JwtUtil jwtUtil;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        if(!(handler instanceof HandlerMethod)) { // 정적 리소스는 곧바로 통과
+            return true;
+        }
+
+        HandlerMethod handlerMethod = (HandlerMethod) handler;
+        if(handlerMethod.hasMethodAnnotation(Authenticated.class)){
+            String token = jwtUtil.extractJwtTokenFromHeader(request);
+
+            if (token == null || !jwtUtil.validateJwtToken(token)) {
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401
+                response.setContentType("application/json;charset=UTF-8"); // 넣어야 인코딩됨
+                response.getWriter().write("{\"message\":\"유효하지 않은 토큰입니다.\"}");
+                return false;
+            }
+
+            String userId = jwtUtil.getSubject(token);
+            if (userId == null) {
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                response.setContentType("application/json;charset=UTF-8");
+                response.getWriter().write("{\"message\":\"토큰에 유저 정보가 없습니다.\"}");
+                return false;
+            }
+
+            request.setAttribute("userId", userId);
+            return true;
+        }
+        return true;
+    }
+
+
+    @Override
+    public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler, ModelAndView modelAndView) throws Exception {
+        HandlerInterceptor.super.postHandle(request, response, handler, modelAndView);
+    }
+
+
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) throws Exception {
+        HandlerInterceptor.super.afterCompletion(request, response, handler, ex);
+    }
+
+}

--- a/src/main/java/com/igemoney/igemoney_BE/common/utils/JwtUtil.java
+++ b/src/main/java/com/igemoney/igemoney_BE/common/utils/JwtUtil.java
@@ -1,0 +1,89 @@
+package com.igemoney.igemoney_BE.common.utils;
+
+
+import com.igemoney.igemoney_BE.user.entity.User;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+
+
+@Component
+public class JwtUtil {
+
+    private final SecretKey secretKey;
+    private final long expirationMs;
+
+    public JwtUtil(@Value("${jwt.secret}") String secretKey, @Value("${jwt.expiration}") long expirationMs) {
+        this.secretKey = Keys.hmacShaKeyFor(secretKey.getBytes());
+        this.expirationMs = expirationMs;
+    }
+
+    public String generateToken(User user) {
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + expirationMs);
+
+        return Jwts.builder()
+            .subject(user.getUserId().toString())
+            .claim("nickname", user.getNickname())
+            .claim("consecutiveAttendance", user.getConsecutiveAttendance().toString())
+            .claim("todayCount", user.getTodayCount())
+            .issuedAt(now)
+            .expiration(expiryDate)
+            .signWith(secretKey, Jwts.SIG.HS256)
+            .compact();
+    }
+
+    public String extractJwtTokenFromHeader(HttpServletRequest request) {
+        String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+
+        if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
+            return authorizationHeader.substring(7);
+        }
+
+        return null;
+    }
+
+    public Boolean validateJwtToken(String token) {
+        try {
+            // jwt를 파싱하는 코드지만 가장 큰 목적은 파싱 도중 잘못된 토큰이면 예외를 뱉어내는 데에 있다
+            Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parse(token);
+            return true;
+
+        } catch (SecurityException e) {
+            throw new IllegalArgumentException("decryption를 실패했습니다.", e);
+        } catch (MalformedJwtException e) {
+            throw new IllegalArgumentException("신뢰할 수 없는 토큰입니다.", e);
+        } catch (ExpiredJwtException e) {
+            throw new IllegalArgumentException("토큰이 만료됐습니다.", e);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("유효하지 않은 토큰입니다.", e);
+        }
+
+    }
+
+    public String getSubject(String token) {
+        try{
+            return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .getSubject();
+        } catch (Exception e) {
+            throw new IllegalArgumentException("유효하지 않은 토큰입니다.", e);
+        }
+    }
+
+
+}

--- a/src/main/java/com/igemoney/igemoney_BE/user/controller/UserController.java
+++ b/src/main/java/com/igemoney/igemoney_BE/user/controller/UserController.java
@@ -1,0 +1,33 @@
+package com.igemoney.igemoney_BE.user.controller;
+
+
+import com.igemoney.igemoney_BE.user.dto.CreateUserRequest;
+import com.igemoney.igemoney_BE.user.dto.LoginResponse;
+import com.igemoney.igemoney_BE.user.service.impl.KakaoServiceImpl;
+import com.igemoney.igemoney_BE.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/user")
+public class UserController {
+
+    private final UserService userService;
+    private final KakaoServiceImpl kakaoService;
+
+    @PostMapping("/register")
+    public LoginResponse register(@RequestBody CreateUserRequest req) {
+        return userService.register(req);
+    }
+
+//    @PostMapping("/login")
+//    public LoginResponse login(@RequestBody LoginRequest req) {
+//        return userService.login(req);
+//    }
+
+}

--- a/src/main/java/com/igemoney/igemoney_BE/user/controller/UserController.java
+++ b/src/main/java/com/igemoney/igemoney_BE/user/controller/UserController.java
@@ -2,6 +2,7 @@ package com.igemoney.igemoney_BE.user.controller;
 
 
 import com.igemoney.igemoney_BE.user.dto.CreateUserRequest;
+import com.igemoney.igemoney_BE.user.dto.LoginRequest;
 import com.igemoney.igemoney_BE.user.dto.LoginResponse;
 import com.igemoney.igemoney_BE.user.service.impl.KakaoServiceImpl;
 import com.igemoney.igemoney_BE.user.service.UserService;
@@ -25,9 +26,9 @@ public class UserController {
         return userService.register(req);
     }
 
-//    @PostMapping("/login")
-//    public LoginResponse login(@RequestBody LoginRequest req) {
-//        return userService.login(req);
-//    }
+    @PostMapping("/login")
+    public LoginResponse login(@RequestBody LoginRequest req) {
+        return userService.login(req);
+    }
 
 }

--- a/src/main/java/com/igemoney/igemoney_BE/user/dto/CreateUserRequest.java
+++ b/src/main/java/com/igemoney/igemoney_BE/user/dto/CreateUserRequest.java
@@ -1,0 +1,8 @@
+package com.igemoney.igemoney_BE.user.dto;
+
+public record CreateUserRequest(
+    String code,
+    String nickname
+) {
+
+}

--- a/src/main/java/com/igemoney/igemoney_BE/user/dto/GetKakaoTokenApiResponse.java
+++ b/src/main/java/com/igemoney/igemoney_BE/user/dto/GetKakaoTokenApiResponse.java
@@ -1,0 +1,27 @@
+package com.igemoney.igemoney_BE.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record GetKakaoTokenApiResponse(
+	@JsonProperty("token_type")
+	String tokenType,
+
+	@JsonProperty("access_token")
+	String accessToken,
+
+	@JsonProperty("id_token")
+	String idToken,
+
+	@JsonProperty("expires_in")
+	Integer expiresIn,
+
+	@JsonProperty("refresh_token")
+	String refreshToken,
+
+	@JsonProperty("refresh_token_expires_in")
+	Integer refreshTokenExpiresIn,
+
+	@JsonProperty("scope")
+	String scope
+) {
+}

--- a/src/main/java/com/igemoney/igemoney_BE/user/dto/GetKakaoUserInfoResponse.java
+++ b/src/main/java/com/igemoney/igemoney_BE/user/dto/GetKakaoUserInfoResponse.java
@@ -1,0 +1,21 @@
+package com.igemoney.igemoney_BE.user.dto;
+
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record GetKakaoUserInfoResponse(
+    Long id,
+    @JsonProperty("kakao_account")
+    KakaoAccount kakaoAccount
+) {
+    public record KakaoAccount(
+        KakaoUserProfile profile
+    ) {
+        public record KakaoUserProfile(
+            String nickname,
+            @JsonProperty("profile_image_url")
+            String profileImageUrl
+        ) {
+        }
+    }
+}

--- a/src/main/java/com/igemoney/igemoney_BE/user/dto/LoginRequest.java
+++ b/src/main/java/com/igemoney/igemoney_BE/user/dto/LoginRequest.java
@@ -1,0 +1,7 @@
+package com.igemoney.igemoney_BE.user.dto;
+
+public record LoginRequest(
+    String code
+) {
+
+}

--- a/src/main/java/com/igemoney/igemoney_BE/user/dto/LoginResponse.java
+++ b/src/main/java/com/igemoney/igemoney_BE/user/dto/LoginResponse.java
@@ -1,0 +1,7 @@
+package com.igemoney.igemoney_BE.user.dto;
+
+public record LoginResponse(
+    String accessToken
+) {
+
+}

--- a/src/main/java/com/igemoney/igemoney_BE/user/entity/User.java
+++ b/src/main/java/com/igemoney/igemoney_BE/user/entity/User.java
@@ -23,7 +23,7 @@ public class User extends BaseEntity {
     private String nickname;
 
     @Column(unique = true)
-    private String oauthId;
+    private Long kakaoOauthId;
 
     @Column
     private Integer ratingPoint;
@@ -40,9 +40,9 @@ public class User extends BaseEntity {
 
     // 가입단에서 유저를 만들 때 사용하는 생성자
     @Builder
-    public User(String nickname, String oauthId) {
+    public User(String nickname, Long oauthId) {
         this.nickname = nickname;
-        this.oauthId = oauthId;
+        this.kakaoOauthId = oauthId;
         this.ratingPoint = 0;
         this.consecutiveAttendance = 1;
         this.todayCount = 0;

--- a/src/main/java/com/igemoney/igemoney_BE/user/repository/UserRepository.java
+++ b/src/main/java/com/igemoney/igemoney_BE/user/repository/UserRepository.java
@@ -1,0 +1,8 @@
+package com.igemoney.igemoney_BE.user.repository;
+
+import com.igemoney.igemoney_BE.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+}

--- a/src/main/java/com/igemoney/igemoney_BE/user/repository/UserRepository.java
+++ b/src/main/java/com/igemoney/igemoney_BE/user/repository/UserRepository.java
@@ -1,8 +1,10 @@
 package com.igemoney.igemoney_BE.user.repository;
 
 import com.igemoney.igemoney_BE.user.entity.User;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
+    Optional<User> findByKakaoOauthId(Long kakaoOauthId);
 }

--- a/src/main/java/com/igemoney/igemoney_BE/user/service/OAuthProvider.java
+++ b/src/main/java/com/igemoney/igemoney_BE/user/service/OAuthProvider.java
@@ -1,0 +1,6 @@
+package com.igemoney.igemoney_BE.user.service;
+
+public interface OAuthProvider<T, I> {
+    T getProviderAccessToken(String authorizationCode);
+    I getProviderUserInfo(String accessToken);
+}

--- a/src/main/java/com/igemoney/igemoney_BE/user/service/UserService.java
+++ b/src/main/java/com/igemoney/igemoney_BE/user/service/UserService.java
@@ -4,6 +4,7 @@ import com.igemoney.igemoney_BE.common.utils.JwtUtil;
 import com.igemoney.igemoney_BE.user.dto.CreateUserRequest;
 import com.igemoney.igemoney_BE.user.dto.GetKakaoTokenApiResponse;
 import com.igemoney.igemoney_BE.user.dto.GetKakaoUserInfoResponse;
+import com.igemoney.igemoney_BE.user.dto.LoginRequest;
 import com.igemoney.igemoney_BE.user.dto.LoginResponse;
 import com.igemoney.igemoney_BE.user.entity.User;
 import com.igemoney.igemoney_BE.user.repository.UserRepository;
@@ -39,4 +40,19 @@ public class UserService {
         return new LoginResponse(jwtToken);
     }
 
+    public LoginResponse login(LoginRequest req) {
+        // 1. 카카오 토큰 발급
+        String kakaoAccessToken = oAuthProvider.getProviderAccessToken(req.code()).accessToken();
+
+        // 2. 발급받은 토큰으로 유저정보 조회해 카카오 oauthId 획득
+        Long kakaoId = oAuthProvider.getProviderUserInfo(kakaoAccessToken).id();
+
+        User user = userRepository.findByKakaoOauthId(kakaoId)
+            .orElseThrow(() -> new IllegalArgumentException("우리 서비스 미가입 카카오 유저입니다. 회원가입 해야 합니다."));
+
+        String jwtToken = jwtUtil.generateToken(user);
+
+        return new LoginResponse(jwtToken);
+
+    }
 }

--- a/src/main/java/com/igemoney/igemoney_BE/user/service/UserService.java
+++ b/src/main/java/com/igemoney/igemoney_BE/user/service/UserService.java
@@ -1,0 +1,42 @@
+package com.igemoney.igemoney_BE.user.service;
+
+import com.igemoney.igemoney_BE.common.utils.JwtUtil;
+import com.igemoney.igemoney_BE.user.dto.CreateUserRequest;
+import com.igemoney.igemoney_BE.user.dto.GetKakaoTokenApiResponse;
+import com.igemoney.igemoney_BE.user.dto.GetKakaoUserInfoResponse;
+import com.igemoney.igemoney_BE.user.dto.LoginResponse;
+import com.igemoney.igemoney_BE.user.entity.User;
+import com.igemoney.igemoney_BE.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final OAuthProvider<GetKakaoTokenApiResponse, GetKakaoUserInfoResponse> oAuthProvider;
+    private final JwtUtil jwtUtil;
+
+
+    public LoginResponse register(CreateUserRequest req) {
+
+        // 1. 카카오 토큰 발급
+        String kakaoAccessToken = oAuthProvider.getProviderAccessToken(req.code()).accessToken();
+
+        // 2. 발급받은 토큰으로 유저정보 조회해 카카오 oauthId 획득
+        Long kakaoId = oAuthProvider.getProviderUserInfo(kakaoAccessToken).id();
+
+        // 3. 닉네임, kakaoOauthId로 새 유저 등록
+        User savedUser = userRepository.save(new User(req.nickname(), kakaoId));
+
+        // 4. 우리 서비스 자체 jwt accessToken 발급
+        // todo: refreshToken 공부해서 적용해보기
+        String jwtToken = jwtUtil.generateToken(savedUser);
+
+        return new LoginResponse(jwtToken);
+    }
+
+}

--- a/src/main/java/com/igemoney/igemoney_BE/user/service/UserService.java
+++ b/src/main/java/com/igemoney/igemoney_BE/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.igemoney.igemoney_BE.user.service;
 
+import com.igemoney.igemoney_BE.common.exception.user.NotRegisteredUserException;
 import com.igemoney.igemoney_BE.common.utils.JwtUtil;
 import com.igemoney.igemoney_BE.user.dto.CreateUserRequest;
 import com.igemoney.igemoney_BE.user.dto.GetKakaoTokenApiResponse;
@@ -47,12 +48,14 @@ public class UserService {
         // 2. 발급받은 토큰으로 유저정보 조회해 카카오 oauthId 획득
         Long kakaoId = oAuthProvider.getProviderUserInfo(kakaoAccessToken).id();
 
+        // 3. 가입하지 않은 유저라면 401에러 리턴
         User user = userRepository.findByKakaoOauthId(kakaoId)
-            .orElseThrow(() -> new IllegalArgumentException("우리 서비스 미가입 카카오 유저입니다. 회원가입 해야 합니다."));
+            .orElseThrow(() -> new NotRegisteredUserException("가입하지 않은 유저입니다. 회원가입 해야 합니다."));
 
         String jwtToken = jwtUtil.generateToken(user);
 
         return new LoginResponse(jwtToken);
 
     }
+
 }

--- a/src/main/java/com/igemoney/igemoney_BE/user/service/impl/KakaoServiceImpl.java
+++ b/src/main/java/com/igemoney/igemoney_BE/user/service/impl/KakaoServiceImpl.java
@@ -1,0 +1,57 @@
+package com.igemoney.igemoney_BE.user.service.impl;
+
+import com.igemoney.igemoney_BE.user.dto.GetKakaoTokenApiResponse;
+import com.igemoney.igemoney_BE.user.dto.GetKakaoUserInfoResponse;
+import com.igemoney.igemoney_BE.user.service.OAuthProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+
+@Service
+public class KakaoServiceImpl implements
+    OAuthProvider<GetKakaoTokenApiResponse, GetKakaoUserInfoResponse> {
+
+    @Value("${kakao.client-id}")
+    private String clientId;
+    @Value("${kakao.redirect-uri}")
+    private String redirectUri;
+
+
+    public GetKakaoTokenApiResponse getProviderAccessToken(String code) {
+        RestClient restClient = RestClient.builder()
+                .baseUrl("https://kauth.kakao.com/oauth/token")
+                .build();
+
+        return restClient.post()
+            .uri(uriBuilder -> uriBuilder
+                .queryParam("grant_type", "authorization_code")
+                .queryParam("client_id", clientId)
+                .queryParam("redirectUri", redirectUri)
+                .queryParam("code", code)
+                .build()
+            )
+            .header("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
+            .retrieve()
+            .body(GetKakaoTokenApiResponse.class);
+    }
+
+
+
+    public GetKakaoUserInfoResponse getProviderUserInfo(String accessToken) {
+        RestClient restClient = RestClient.builder()
+            .baseUrl("https://kapi.kakao.com/v2/user/me")
+            .build();
+
+        GetKakaoUserInfoResponse response = restClient.post()
+            .header("Authorization", "Bearer " + accessToken)
+            .header("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
+            .retrieve()
+            .body(GetKakaoUserInfoResponse.class);
+
+        System.out.println(response.toString());
+
+        return response;
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,9 +4,9 @@ spring:
 
   # todo: .env 도입 시 배포단과 분리해 적용되는 스크립트 작성하기
   datasource:
-    url: jdbc:mysql://localhost:3306/igemoney-mysql
-    username: root
-    password: 1234
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:
@@ -24,4 +24,13 @@ spring:
       mode: always
       data-locations: classpath:data.sql
       encoding: utf-8
+
+
+jwt:
+  secret: ${JWT_SECRET_KEY}
+  expiration: 864000000 # 240 hours for dev
+
+kakao:
+  client-id: ${KAKAO_CLIENT_ID}
+  redirect-uri: http://localhost:8080
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

closes #20 
closes #22 
closes #23 
closes #24 
closes #25 

## #️⃣ 작업 내용
- 카카오 소셜 로그인, 회원가입 기능을 구현했습니다
- 이 과정에서 미가입 유저는 401을 리턴해야하기 때문에 커스텀 에러를 만들어 전역 에러 핸들러에서 해당 오류에 대해 401이 담긴 ResponseEntity를 리턴하도록 했습니다.
- 컨트롤러별로 수제 어노테이션 @Authenticated 을 붙여 token이 존재하는, 즉 인가된 유저만 사용 가능한 기능을 구분하고 컨트롤러에서 현재 로그인한 유저의 userId를 가져올 수 있도록 했습니다.
- dotenv를 설치해 yml에서 민감한 정보를 외부에 노출시키지 않도록 했습니다.
