### PR TITLE
배포서버 단 로그 타임스탬프 시간대를 한국으로 지정

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,3 +34,6 @@ kakao:
   client-id: ${KAKAO_CLIENT_ID:5e45005280acdac029d1a800d58c709e}
   redirect-uri: http://localhost:8080
 
+logging:
+  pattern:
+    dateformat: "yyyy-MM-dd HH:mm:ss.SSS, Asia/Seoul"


### PR DESCRIPTION
메인 함수에 해준 처리는 스프링 애플리케이션 자체의 시간대에 대한 작업이지만 로깅 프레임워크에 대한 처리는 아니라 yml에 지정했습니다.

이게 안되면 DockerFile에 직접 컨테이너 환경의 시간대 설정을 다음처럼 하려 합니다.

```java
ENV TZ=Asia/Seoul
```