### PR TITLE
fix: 공통용 기반으로 개발환경, 배포환경별 yml 설정

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,19 @@
+spring:
+  config:
+    activate:
+      on-profile: dev
+
+  datasource:
+    url: ${DB_URL:jdbc:mysql://localhost:3306/igemoney-mysql}
+    username: ${DB_USERNAME:root}
+    password: ${DB_PASSWORD:1234}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+  sql:
+    init:
+      mode: always
+      data-locations: classpath:data.sql
+      encoding: utf-8

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,20 @@
+spring:
+  config:
+    activate:
+      on-profile: prod
+
+  datasource:
+    url: ${PROD_DB_URL:jdbc:mysql-container://mysql:3306/igemoney-mysql}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: update # 배포에선 update or validate
+    properties:
+      hibernate:
+        format_sql: false
+  sql:
+    init:
+      mode: never # 운영에선 data.sql 안씀

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,39 +1,23 @@
 spring:
   application:
     name: igemoney_BE
-
-  # todo: .env 도입 시 배포단과 분리해 적용되는 스크립트 작성하기
-  datasource:
-    url: ${DB_URL:jdbc:mysql://127.0.0.1:3306/igemoney-mysql}
-    username: ${DB_USERNAME:root}
-    password: ${DB_PASSWORD:1234}
-    driver-class-name: com.mysql.cj.jdbc.Driver
+  profiles:
+    default: dev
 
   jpa:
-    hibernate:
-      # todo: 배포단에선 update로 바꾸기
-      ddl-auto: create
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.MySQLDialect
         format_sql: true
     defer-datasource-initialization: true
 
-  sql:
-    init:
-      mode: always
-      data-locations: classpath:data.sql
-      encoding: utf-8
-
-
 jwt:
-  secret: ${JWT_SECRET_KEY:thisIsTemporalDefaultJwtSecretKeyNotForDevButCIPassing}
-  expiration: 864000000 # 240 hours for dev
-
-kakao:
-  client-id: ${KAKAO_CLIENT_ID:5e45005280acdac029d1a800d58c709e}
-  redirect-uri: http://localhost:8080
+  secret: ${JWT_SECRET_KEY:this_is_temporal_default_jwt_secret_key_not_for_dev_but_ci_passing}
+  expiration: 864000000 # 240h
 
 logging:
   pattern:
     dateformat: "yyyy-MM-dd HH:mm:ss.SSS, Asia/Seoul"
+
+kakao:
+  client-id: ${KAKAO_CLIENT_ID}
+  redirect-uri: ${KAKAO_REDIRECT_URI:http://localhost:8080}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#68 

## #️⃣ 작업 내용
서버 실행 환경별 프로퍼티값 다르게 적용하는 작업을 했습니다.
docker container는 호스트 머신 위에서 독립적으로 돌아가는 실행 환경입니다. (경량화된 가상머신이라 생각해도 됨)
- 개발 환경에선 서버를 컨테이너 없이 직접 실행했기 때문에 was가 가리키는 db_url인 localhost:3306은 로컬에 열린 디비에 바로 접속 가능했습니다.
- 근데 배포 환경에선 was도 컨테이너로 감싸고 있습니다. 이때의localhost는 was 컨테이너가 돌아가는 환경을 의미하게 됩니다. db는 이 환경 바깥의 host machine을 또 빌려쓰는 mysql 컨테이너입니다.

이 즈음부터 개발환경과 배포환경별 다르게 적용되는 값들이 존재하기 시작했기 때문에 이 작업을 했습니다.
(docker compose도 고려해보긴 했는데 러닝커브 + 컨테이너가 2개밖에 없는데 굳이? 이슈로 아직은 도입안하기로 결정)
