### PR TITLE
CD was run 명령어에 network 옵션 추가

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -70,6 +70,7 @@ jobs:
 
             # 3. 새 컨테이너를 실행 (커밋 해시 버전으로, .env 파일 사용, prod 프로파일 활성화)
             sudo docker run -d --name igemoney-be \
+            --network igemoney-net \
             --env-file ~/igemoney-be.env \
             -e SPRING_PROFILES_ACTIVE=prod \
             -p 8080:8080 ${{ secrets.DOCKER_USERNAME }}/igemoney-be:$COMMIT_HASH


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#68 

## #️⃣ 작업 내용

- db_url의 디비 컨테이너명을 읽어내지 못하는 오류가 있었음
- 원인은 컨테이너명을 통한 다른 컨테이너 접속을 도와주는 DNS 서비스를 이용치 못하고 있었음
- 왜와이? was 배포는 기존 컨테이너를 삭제하고 새로 pull 받는 구조이기 때문에 db 컨테이너와 같은 네트워크에 속해있지 않음

애초에 디비 컨테이너도 기본 브릿지 네트워크 소속이었음. 따라서 docker network create로 네트워크를 만들어 붙여줘야했음
그래서 배포서버단에서 해당 작업을 수행했고 배포마다 was 컨테이너 run 스크립트 시 network를 만든 네트워크로 지정하는 옵션을 추가

