### PR TITLE
feat: 연속 출석 api 구현

### DIFF
--- a/src/main/java/com/igemoney/igemoney_BE/attendance/controller/AttendanceController.java
+++ b/src/main/java/com/igemoney/igemoney_BE/attendance/controller/AttendanceController.java
@@ -5,14 +5,13 @@ import com.igemoney.igemoney_BE.attendance.service.AttendanceService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.NoSuchElementException;
 
+
 @RestController
+@RequestMapping("/api/users/me")
 @Tag(name = "User Attendence", description = "사용자 출석 API")
 public class AttendanceController {
 
@@ -22,7 +21,7 @@ public class AttendanceController {
         this.attendanceService = attendanceService;
     }
 
-    @GetMapping("/api/users/me/attendance")
+    @GetMapping("/attendance")
     public ResponseEntity<?> attendance(@RequestHeader("Authorization") String authorizationHeader) {
         try {
             Long kakaoOauthId = extractOauthIdFromJwt(authorizationHeader);
@@ -34,7 +33,7 @@ public class AttendanceController {
         }
     }
 
-    @PostMapping("/api/users/me/attendence/solve")
+    @PostMapping("/attendance/solve")
     public ResponseEntity<?> incrementSolvedCount(@RequestHeader("Authorization") String authorizationHeader) {
         try {
             Long kakaoOauthId = extractOauthIdFromJwt(authorizationHeader);

--- a/src/main/java/com/igemoney/igemoney_BE/attendance/controller/AttendanceController.java
+++ b/src/main/java/com/igemoney/igemoney_BE/attendance/controller/AttendanceController.java
@@ -31,18 +31,6 @@ public class AttendanceController {
         }
     }
 
-    @PostMapping("/attendance/solve")
-    public ResponseEntity<?> incrementSolvedCount(@RequestHeader("Authorization") String authorizationHeader) {
-        try {
-            Long kakaoOauthId = extractOauthIdFromJwt(authorizationHeader);
-            attendanceService.incrementTodaySolvedCount(kakaoOauthId);
-            return ResponseEntity.ok("오늘 푼 문제 수가 증가했습니다.");
-        } catch (NoSuchElementException e) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                    .body("해당 유저를 찾을 수 없습니다.");
-        }
-    }
-
     private Long extractOauthIdFromJwt(String token) {
         // JWT 파싱 로직 (실제로 JWT 라이브러리 사용 권장)
         // 임시

--- a/src/main/java/com/igemoney/igemoney_BE/attendance/controller/AttendanceController.java
+++ b/src/main/java/com/igemoney/igemoney_BE/attendance/controller/AttendanceController.java
@@ -3,6 +3,7 @@ package com.igemoney.igemoney_BE.attendance.controller;
 import com.igemoney.igemoney_BE.attendance.dto.AttendanceResponseDto;
 import com.igemoney.igemoney_BE.attendance.service.AttendanceService;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -11,15 +12,12 @@ import java.util.NoSuchElementException;
 
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/api/users/me")
 @Tag(name = "User Attendence", description = "사용자 출석 API")
 public class AttendanceController {
 
     private final AttendanceService attendanceService;
-
-    public AttendanceController(AttendanceService attendanceService) {
-        this.attendanceService = attendanceService;
-    }
 
     @GetMapping("/attendance")
     public ResponseEntity<?> attendance(@RequestHeader("Authorization") String authorizationHeader) {

--- a/src/main/java/com/igemoney/igemoney_BE/attendance/controller/AttendanceController.java
+++ b/src/main/java/com/igemoney/igemoney_BE/attendance/controller/AttendanceController.java
@@ -4,12 +4,8 @@ import com.igemoney.igemoney_BE.attendance.dto.AttendanceResponseDto;
 import com.igemoney.igemoney_BE.attendance.service.AttendanceService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.NoSuchElementException;
-
 
 @RestController
 @RequiredArgsConstructor
@@ -21,14 +17,9 @@ public class AttendanceController {
 
     @GetMapping("/attendance")
     public ResponseEntity<?> attendance(@RequestHeader("Authorization") String authorizationHeader) {
-        try {
-            Long kakaoOauthId = extractOauthIdFromJwt(authorizationHeader);
-            AttendanceResponseDto response = attendanceService.getTodayAttendance(kakaoOauthId);
-            return ResponseEntity.ok(response);
-        } catch (NoSuchElementException e) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                    .body("해당 유저를 찾을 수 없습니다.");
-        }
+        Long kakaoOauthId = extractOauthIdFromJwt(authorizationHeader);
+        AttendanceResponseDto response = attendanceService.getTodayAttendance(kakaoOauthId);
+        return ResponseEntity.ok(response);
     }
 
     private Long extractOauthIdFromJwt(String token) {

--- a/src/main/java/com/igemoney/igemoney_BE/attendance/exception/AttendanceNotFoundException.java
+++ b/src/main/java/com/igemoney/igemoney_BE/attendance/exception/AttendanceNotFoundException.java
@@ -1,0 +1,7 @@
+package com.igemoney.igemoney_BE.attendance.exception;
+
+public class AttendanceNotFoundException extends Exception {
+    public AttendanceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/igemoney/igemoney_BE/attendance/handler/AttendanceExceptionHandler.java
+++ b/src/main/java/com/igemoney/igemoney_BE/attendance/handler/AttendanceExceptionHandler.java
@@ -1,0 +1,16 @@
+package com.igemoney.igemoney_BE.attendance.handler;
+
+import com.igemoney.igemoney_BE.attendance.exception.AttendanceNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice(basePackages = "com.igemoney.igemoney_BE.attendance")
+public class AttendanceExceptionHandler {
+    @ExceptionHandler(AttendanceNotFoundException.class)
+    public ResponseEntity<String> handleAttendanceNotFound(AttendanceNotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body("Attendance Error: " + ex.getMessage());
+    }
+}

--- a/src/main/java/com/igemoney/igemoney_BE/attendance/scheduler/AttendanceScheduler.java
+++ b/src/main/java/com/igemoney/igemoney_BE/attendance/scheduler/AttendanceScheduler.java
@@ -1,0 +1,20 @@
+package com.igemoney.igemoney_BE.attendance.scheduler;
+
+import com.igemoney.igemoney_BE.attendance.service.AttendanceService;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AttendanceScheduler {
+
+    private final AttendanceService attendanceService;
+
+    public AttendanceScheduler(AttendanceService attendanceService) {
+        this.attendanceService = attendanceService;
+    }
+
+    @Scheduled(cron = "0 0 0 * * *") // 매일 자정 실행
+    public void runAttendanceUpdate() {
+        attendanceService.updateAttendanceForAllUsers();
+    }
+}

--- a/src/main/java/com/igemoney/igemoney_BE/attendance/scheduler/AttendanceScheduler.java
+++ b/src/main/java/com/igemoney/igemoney_BE/attendance/scheduler/AttendanceScheduler.java
@@ -1,17 +1,15 @@
 package com.igemoney.igemoney_BE.attendance.scheduler;
 
 import com.igemoney.igemoney_BE.attendance.service.AttendanceService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class AttendanceScheduler {
 
     private final AttendanceService attendanceService;
-
-    public AttendanceScheduler(AttendanceService attendanceService) {
-        this.attendanceService = attendanceService;
-    }
 
     @Scheduled(cron = "0 0 0 * * *") // 매일 자정 실행
     public void runAttendanceUpdate() {

--- a/src/main/java/com/igemoney/igemoney_BE/attendance/scheduler/AttendanceScheduler.java
+++ b/src/main/java/com/igemoney/igemoney_BE/attendance/scheduler/AttendanceScheduler.java
@@ -13,6 +13,6 @@ public class AttendanceScheduler {
 
     @Scheduled(cron = "0 0 0 * * *") // 매일 자정 실행
     public void runAttendanceUpdate() {
-        attendanceService.updateAttendanceForAllUsers();
+        attendanceService.resetAttendanceForAllUsers();
     }
 }

--- a/src/main/java/com/igemoney/igemoney_BE/attendance/service/AttendanceService.java
+++ b/src/main/java/com/igemoney/igemoney_BE/attendance/service/AttendanceService.java
@@ -6,6 +6,7 @@ import com.igemoney.igemoney_BE.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.NoSuchElementException;
 
 @Service
@@ -37,5 +38,18 @@ public class AttendanceService {
         user.increaseTodaySolvedCount();
 
         userRepository.save(user);
+    }
+
+    public void updateAttendanceWithoutQuery() {
+        List<User> users = userRepository.findAll();
+        for (User user : users) {
+            if (user.getTodayCount() >= 5) {
+                user.increaseConsecutiveAttendance();
+            } else {
+                user.resetConsecutiveAttendance();
+            }
+            user.resetTodaySolvedCount();
+        }
+        userRepository.saveAll(users);
     }
 }

--- a/src/main/java/com/igemoney/igemoney_BE/attendance/service/AttendanceService.java
+++ b/src/main/java/com/igemoney/igemoney_BE/attendance/service/AttendanceService.java
@@ -3,6 +3,7 @@ package com.igemoney.igemoney_BE.attendance.service;
 import com.igemoney.igemoney_BE.attendance.dto.AttendanceResponseDto;
 import com.igemoney.igemoney_BE.user.entity.User;
 import com.igemoney.igemoney_BE.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -10,14 +11,11 @@ import java.util.List;
 import java.util.NoSuchElementException;
 
 @Service
+@RequiredArgsConstructor
 @Transactional
 public class AttendanceService {
 
     private final UserRepository userRepository;
-
-    public AttendanceService(UserRepository userRepository) {
-        this.userRepository = userRepository;
-    }
 
     private static final int ATTENDANCE_THRESHOLD = 5;
 

--- a/src/main/java/com/igemoney/igemoney_BE/attendance/service/AttendanceService.java
+++ b/src/main/java/com/igemoney/igemoney_BE/attendance/service/AttendanceService.java
@@ -34,16 +34,17 @@ public class AttendanceService {
                 .orElseThrow(() -> new NoSuchElementException("User not found"));
 
         user.increaseTodaySolvedCount();
+        if (user.getTodayCount() == 5) {
+            user.increaseConsecutiveAttendance();
+        }
 
         userRepository.save(user);
     }
 
-    public void updateAttendanceForAllUsers() {
+    public void resetAttendanceForAllUsers() {
         List<User> users = userRepository.findAll();
         for (User user : users) {
-            if (user.getTodayCount() >= 5) {
-                user.increaseConsecutiveAttendance();
-            } else {
+            if (user.getTodayCount() < 5) {
                 user.resetConsecutiveAttendance();
             }
             user.resetTodaySolvedCount();

--- a/src/main/java/com/igemoney/igemoney_BE/attendance/service/AttendanceService.java
+++ b/src/main/java/com/igemoney/igemoney_BE/attendance/service/AttendanceService.java
@@ -40,7 +40,7 @@ public class AttendanceService {
         userRepository.save(user);
     }
 
-    public void updateAttendanceWithoutQuery() {
+    public void updateAttendanceForAllUsers() {
         List<User> users = userRepository.findAll();
         for (User user : users) {
             if (user.getTodayCount() >= 5) {

--- a/src/main/java/com/igemoney/igemoney_BE/user/entity/User.java
+++ b/src/main/java/com/igemoney/igemoney_BE/user/entity/User.java
@@ -54,9 +54,16 @@ public class User extends BaseEntity {
         this.todayCount++;
     }
 
+    public void resetTodaySolvedCount() {
+        this.todayCount = 0;
+    }
 
-    public void updateConsecutiveAttendance(Integer consecutiveAttendance) {
-        this.consecutiveAttendance = consecutiveAttendance;
+    public void increaseConsecutiveAttendance() {
+        this.consecutiveAttendance++;
+    }
+
+    public  void resetConsecutiveAttendance() {
+        this.consecutiveAttendance = 0;
     }
 
 

--- a/src/test/java/com/igemoney/igemoney_BE/attendance/AttendanceServiceTest.java
+++ b/src/test/java/com/igemoney/igemoney_BE/attendance/AttendanceServiceTest.java
@@ -42,6 +42,8 @@ public class AttendanceServiceTest {
             user2.increaseTodaySolvedCount();
         }
 
+        attendanceService.updateAttendanceForAllUsers();
+
         assertEquals(2, user1.getConsecutiveAttendance());
         assertEquals(0, user1.getTodayCount());
         assertEquals(0, user2.getConsecutiveAttendance());

--- a/src/test/java/com/igemoney/igemoney_BE/attendance/AttendanceServiceTest.java
+++ b/src/test/java/com/igemoney/igemoney_BE/attendance/AttendanceServiceTest.java
@@ -1,0 +1,50 @@
+package com.igemoney.igemoney_BE.attendance;
+
+import com.igemoney.igemoney_BE.attendance.service.AttendanceService;
+import com.igemoney.igemoney_BE.user.entity.User;
+import com.igemoney.igemoney_BE.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+@Transactional
+public class AttendanceServiceTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private AttendanceService attendanceService;
+
+    @BeforeEach
+    public void setUp() {
+        userRepository.deleteAll();
+        userRepository.save(new User("test1", 1L)); // todayCount 5 이상
+        userRepository.save(new User("test2", 2L)); // todayCount 5 미만
+    }
+
+    @Test
+    public void testUpdateAttendanceForAllUsers() {
+        User user1 = userRepository.findById(1L).get();
+        User user2 = userRepository.findById(2L).get();
+
+        for(int i=0; i<5; i++) {
+            user1.increaseTodaySolvedCount();
+        }
+
+        user2.increaseConsecutiveAttendance();
+        for(int i=0; i<2; i++) {
+            user2.increaseTodaySolvedCount();
+        }
+
+        assertEquals(2, user1.getConsecutiveAttendance());
+        assertEquals(0, user1.getTodayCount());
+        assertEquals(0, user2.getConsecutiveAttendance());
+        assertEquals(0, user2.getTodayCount());
+    }
+}

--- a/src/test/java/com/igemoney/igemoney_BE/attendance/AttendanceServiceTest.java
+++ b/src/test/java/com/igemoney/igemoney_BE/attendance/AttendanceServiceTest.java
@@ -34,15 +34,15 @@ public class AttendanceServiceTest {
         User user2 = userRepository.findById(2L).get();
 
         for(int i=0; i<5; i++) {
-            user1.increaseTodaySolvedCount();
+            attendanceService.incrementTodaySolvedCount(1L);
         }
 
         user2.increaseConsecutiveAttendance();
         for(int i=0; i<2; i++) {
-            user2.increaseTodaySolvedCount();
+            attendanceService.incrementTodaySolvedCount(2L);
         }
 
-        attendanceService.updateAttendanceForAllUsers();
+        attendanceService.resetAttendanceForAllUsers();
 
         assertEquals(2, user1.getConsecutiveAttendance());
         assertEquals(0, user1.getTodayCount());

--- a/src/test/java/com/igemoney/igemoney_BE/attendance/controller/AttendanceControllerTest.java
+++ b/src/test/java/com/igemoney/igemoney_BE/attendance/controller/AttendanceControllerTest.java
@@ -1,0 +1,4 @@
+package com.igemoney.igemoney_BE.attendance.controller;
+
+public class AttendanceControllerTest {
+}

--- a/src/test/java/com/igemoney/igemoney_BE/attendance/service/AttendanceServiceTest.java
+++ b/src/test/java/com/igemoney/igemoney_BE/attendance/service/AttendanceServiceTest.java
@@ -1,6 +1,5 @@
-package com.igemoney.igemoney_BE.attendance;
+package com.igemoney.igemoney_BE.attendance.service;
 
-import com.igemoney.igemoney_BE.attendance.service.AttendanceService;
 import com.igemoney.igemoney_BE.user.entity.User;
 import com.igemoney.igemoney_BE.user.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #79

## #️⃣ 작업 내용

출석 api 피드백 반영 
- 중복 경로 내용 `@RequestMapping`
- `lombok` 통일
- 출석 예외 핸들러 구현

연속 출석 구현
- 당일 문제 풀이 카운트(`todayCount`)가 5가 되면 연속 출석 카운트(`consecutiveAttendance`) 1 증가
- 자정마다 모든 user의 `todayCount`를 조회하여 5 미만이면 0으로 초기화
- `todayCount` 0으로 초기화
- 연속 출석 테스트 코드 구현

추후 수정 계획
- 유저 아이디 사용에 대해 `@RequestAttribute("userId")` 적용
- 출석 카운트 증가 컨트롤러 코드 제거 및 퀴즈 풀이에 대한 답변을 받을 때 출석 카운트 증가 메서드 호출
- 연속 출석 카운트 증가 안정성을 높이기 위해 User 엔티티에 당일 출석 여부 플래그 속성 추가

## #️⃣ 스크린샷 (선택)

> 관련된 스크린샷이 있다면 여기에 첨부해주세요.


## 주의사항
1. 환경변수가 추가되는 작업이면 팀원에게 알리기
2. 문제를 해결했다면 꼭 노션의 위클리 프로젝트 트러블 슈팅로그에 작성
3. 리팩토링 해볼만 할 것 같은 부분이 있다면 메모
