### PR TITLE
feat: 오답 복습 문제 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/igemoney/igemoney_BE/common/interceptor/AuthenticationInterceptor.java
+++ b/src/main/java/com/igemoney/igemoney_BE/common/interceptor/AuthenticationInterceptor.java
@@ -34,11 +34,11 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
                 throw new UnvalidJwtTokenException("토큰이 없거나 유효하지 않은 토큰입니다.");
             }
 
-            String userId = jwtUtil.getSubject(token);
-            if (userId == null) {
+            String subject = jwtUtil.getSubject(token);
+            if (subject == null) {
                 throw new NoUserIdTokenException("토큰에 유저 식별자가 없습니다.");
             }
-
+            Long userId = Long.parseLong(subject);
             request.setAttribute("userId", userId);
             return true;
         }

--- a/src/main/java/com/igemoney/igemoney_BE/quiz/controller/QuizController.java
+++ b/src/main/java/com/igemoney/igemoney_BE/quiz/controller/QuizController.java
@@ -1,7 +1,9 @@
 package com.igemoney.igemoney_BE.quiz.controller;
 
+import com.igemoney.igemoney_BE.common.annotation.Authenticated;
 import com.igemoney.igemoney_BE.quiz.dto.QuizCreateRequest;
 import com.igemoney.igemoney_BE.quiz.dto.QuizResponse;
+import com.igemoney.igemoney_BE.quiz.dto.QuizReviewResponse;
 import com.igemoney.igemoney_BE.quiz.dto.QuizSubmitRequest;
 import com.igemoney.igemoney_BE.quiz.service.QuizService;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -40,6 +42,12 @@ public class QuizController {
     @PostMapping("/{id}/submit")
     public void submitQuizResult(@PathVariable Long id, @RequestBody QuizSubmitRequest request) {
         quizService.submitQuizResult(id, request);
+    }
+
+    @Authenticated
+    @GetMapping("/review")
+    public QuizReviewResponse getQuizReview(@RequestAttribute("userId") Long userId) {
+        return quizService.getQuizReview(userId);
     }
 
 

--- a/src/main/java/com/igemoney/igemoney_BE/quiz/dto/QuizReviewResponse.java
+++ b/src/main/java/com/igemoney/igemoney_BE/quiz/dto/QuizReviewResponse.java
@@ -1,0 +1,10 @@
+package com.igemoney.igemoney_BE.quiz.dto;
+
+import java.util.List;
+
+public record QuizReviewResponse (
+        Boolean hasReviewQuizzes,
+        List<ReviewQuizDetail> reviewQuizzes
+){
+}
+

--- a/src/main/java/com/igemoney/igemoney_BE/quiz/dto/ReviewQuizDetail.java
+++ b/src/main/java/com/igemoney/igemoney_BE/quiz/dto/ReviewQuizDetail.java
@@ -1,0 +1,40 @@
+package com.igemoney.igemoney_BE.quiz.dto;
+
+import com.igemoney.igemoney_BE.quiz.entity.Quiz;
+import com.igemoney.igemoney_BE.quiz.entity.UserQuizAttempt;
+import com.igemoney.igemoney_BE.quiz.entity.enums.DifficultyLevel;
+import com.igemoney.igemoney_BE.quiz.entity.enums.QuestionType;
+import com.igemoney.igemoney_BE.quiz.entity.enums.ReviewStep;
+import com.igemoney.igemoney_BE.topic.entity.QuizTopic;
+
+import java.math.BigDecimal;
+
+public record ReviewQuizDetail(
+        Long quizId,
+        Long topicId,
+        String questionTitle,
+        QuestionType questionType,
+        String questionData,
+        DifficultyLevel difficultyLevel,
+        String explanation,
+        BigDecimal correctRate,
+        ReviewStep reviewStep
+) {
+    public static ReviewQuizDetail from(UserQuizAttempt attempt){
+        Quiz quiz = attempt.getQuiz();
+        QuizTopic topic = quiz.getTopic();
+        ReviewStep reviewStep = attempt.getReviewStep();
+
+        return new ReviewQuizDetail(
+                quiz.getId(),
+                topic.getId(),
+                quiz.getQuestionTitle(),
+                quiz.getQuestionType(),
+                quiz.getQuestionData(),
+                quiz.getDifficultyLevel(),
+                quiz.getExplanation(),
+                quiz.getCorrectRate(),
+                reviewStep
+        );
+    }
+}

--- a/src/main/java/com/igemoney/igemoney_BE/quiz/repository/UserQuizAttemptRepository.java
+++ b/src/main/java/com/igemoney/igemoney_BE/quiz/repository/UserQuizAttemptRepository.java
@@ -3,7 +3,20 @@ package com.igemoney.igemoney_BE.quiz.repository;
 
 import com.igemoney.igemoney_BE.quiz.entity.UserQuizAttempt;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 
 public interface UserQuizAttemptRepository extends JpaRepository<UserQuizAttempt, Long> {
+
+    @Query("""
+        SELECT a 
+        FROM UserQuizAttempt a 
+        JOIN FETCH a.quiz q 
+        JOIN FETCH q.topic t 
+        WHERE a.user.userId = :userId
+    """)
+    List<UserQuizAttempt> findReviewAttemptsWithQuizAndTopic(@Param("userId") Long userId);
 }

--- a/src/main/java/com/igemoney/igemoney_BE/quiz/service/QuizService.java
+++ b/src/main/java/com/igemoney/igemoney_BE/quiz/service/QuizService.java
@@ -1,9 +1,7 @@
 package com.igemoney.igemoney_BE.quiz.service;
 
 
-import com.igemoney.igemoney_BE.quiz.dto.QuizCreateRequest;
-import com.igemoney.igemoney_BE.quiz.dto.QuizResponse;
-import com.igemoney.igemoney_BE.quiz.dto.QuizSubmitRequest;
+import com.igemoney.igemoney_BE.quiz.dto.*;
 import com.igemoney.igemoney_BE.quiz.entity.UserQuizAttempt;
 import com.igemoney.igemoney_BE.quiz.entity.Quiz;
 import com.igemoney.igemoney_BE.topic.entity.QuizTopic;
@@ -16,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 
 @Service
@@ -58,6 +57,19 @@ public class QuizService {
 			.orElseThrow(() -> new IllegalArgumentException("Quiz not found"));
 
 		return QuizResponse.from(quiz);
+	}
+
+	public QuizReviewResponse getQuizReview(Long userId) {
+		List<UserQuizAttempt> attempts = userQuizAttemptRepository.findReviewAttemptsWithQuizAndTopic(userId);
+
+		List<ReviewQuizDetail> quizDetails = attempts.stream()
+			.map(ReviewQuizDetail::from)
+			.toList();
+
+		return new QuizReviewResponse(
+				!quizDetails.isEmpty(),
+				quizDetails
+		);
 	}
 
 

--- a/src/main/java/com/igemoney/igemoney_BE/quiz/service/QuizService.java
+++ b/src/main/java/com/igemoney/igemoney_BE/quiz/service/QuizService.java
@@ -14,7 +14,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 
 @Service

--- a/src/main/java/com/igemoney/igemoney_BE/user/entity/User.java
+++ b/src/main/java/com/igemoney/igemoney_BE/user/entity/User.java
@@ -22,7 +22,7 @@ public class User extends BaseEntity {
     @Column(name = "nickname", unique = true, nullable = false)
     private String nickname;
 
-    @Column(unique = true)
+    @Column(name = "kakao_oauth_id", unique = true)
     private Long kakaoOauthId;
 
     @Column


### PR DESCRIPTION
## #️⃣ 연관된 이슈

closes #48 

## #️⃣ 작업 내용

퀴즈 복습 문제 API 구현하였습니다.
API 문서에 있는대로 틀린 문제가 있는지(boolean), 틀린 문제들에 대한 정보(배열)를 response로 전달합니다. 
JWT에서 사용자 아이디(Long 타입)를 들고 오는데 타입 충돌이 생겨서 Interceptor에서 이를 수정하였습니다.

## #️⃣ 스크린샷 (선택)

<img width="1591" height="584" alt="image" src="https://github.com/user-attachments/assets/cf7c2762-110d-4357-872f-0db5acda9f00" />

